### PR TITLE
fix call of mktemp, requires a template on OS X

### DIFF
--- a/spec/framework/run.sh
+++ b/spec/framework/run.sh
@@ -16,15 +16,10 @@ echo
 . $(dirname "$0")/tests.sh
 . $(dirname "$0")/verify.sh
 
-if [ -z "$TMPDIR" ]; then
-    TEMPDIR="$TMPDIR"
-else
-    TEMPDIR="/tmp"
-fi
-
+temp=${TMPDIR-${TEMP-${TMP-/tmp}}}
 result=0
 for markdown in "$@" ; do
-  DIR=$(mktemp -d "$TEMPDIR/tmp.XXXXXXXXXX")
+  DIR=$(mktemp -d "$temp/tmp.XXXXXXXXXX")
   case $(uname) in
     CYGWIN*) EXE=xp.exe ; cp xp.exe "$DIR" ;;
     Darwin*) EXE=xp ; cp xp xp.exe "$DIR" ;;

--- a/spec/framework/run.sh
+++ b/spec/framework/run.sh
@@ -16,9 +16,15 @@ echo
 . $(dirname "$0")/tests.sh
 . $(dirname "$0")/verify.sh
 
+if [ -z "$TMPDIR" ]; then
+    TEMPDIR="$TMPDIR"
+else
+    TEMPDIR="/tmp"
+fi
+
 result=0
 for markdown in "$@" ; do
-  DIR=$(mktemp -d)
+  DIR=$(mktemp -d "$TEMPDIR/tmp.XXXXXXXXXX")
   case $(uname) in
     CYGWIN*) EXE=xp.exe ; cp xp.exe "$DIR" ;;
     Darwin*) EXE=xp ; cp xp xp.exe "$DIR" ;;


### PR DESCRIPTION
This PR fixes the problem that the mktemp command on OS X requires a template as argument, which is not required on the Linux version of the command.
